### PR TITLE
fix: git_is_empty doesn't work on recent git versions

### DIFF
--- a/git_is_empty.fish
+++ b/git_is_empty.fish
@@ -1,7 +1,8 @@
 function git_is_empty -d "Test if a repository is empty"
-    if command git rev-list -n 1 --all > /dev/null 2>/dev/null
+    if git_is_repo
+        and test -z (command git rev-list -n 1 --all 2>/dev/null)
+        return 0
+    else
         return 1
     end
-
-    git_is_repo
 end


### PR DESCRIPTION
On recent git versions, `git rev-list` doesn't throw on empty repos.

I was looking around the git changelogs but I cannot find when exactly
was this changed.

With this change, the behavior stays equivalent on old and new git
versions.